### PR TITLE
Fixes compilation error in examples due to macro F

### DIFF
--- a/examples/RF24Mesh_Example_Master_To_Nodes/RF24Mesh_Example_Master_To_Nodes.ino
+++ b/examples/RF24Mesh_Example_Master_To_Nodes/RF24Mesh_Example_Master_To_Nodes.ino
@@ -84,7 +84,12 @@ void loop() {
         payload = {ctr%3,ctr};
       }
       RF24NetworkHeader header(mesh.addrList[i].address, OCT); //Constructing a header
-      Serial.println( F(network.write(header, &payload, sizeof(payload)) == 1 ? "Send OK" : "Send Fail")); //Sending an message
+      if (network.write(header, &payload, sizeof(payload))){	  //Sending an message
+	    Serial.println(F("Send Ok"));
+	  }
+	  else {
+        Serial.println(F("Send Fail"));
+      }
       
     }
     displayTimer = millis();


### PR DESCRIPTION
Macro F only accepts string literals, hence it causes a compilation
error when you have a function or variable inside.

**Example:**
String msg = "test";
Serial.println(F(msg));

**Proposed Fix:**
Removed ternary condition and function to a separate if-else block.